### PR TITLE
Various quickfixes

### DIFF
--- a/assets/svg/double-down-arrow.svg
+++ b/assets/svg/double-down-arrow.svg
@@ -1,0 +1,6 @@
+<svg width="25" height="25" viewBox="0 0 26 23" fill="none" xmlns="http://www.w3.org/2000/svg">
+<line x1="0.707107" y1="1.29289" x2="13.7071" y2="14.2929" stroke="var(--dark-grey)" stroke-width="2"/>
+<line x1="0.707107" y1="9.29289" x2="13.7071" y2="22.2929" stroke="var(--dark-grey)" stroke-width="2"/>
+<line y1="-1" x2="18.3848" y2="-1" transform="matrix(-0.707107 0.707107 0.707107 0.707107 26 2)" stroke="var(--dark-grey)" stroke-width="2"/>
+<line y1="-1" x2="18.3848" y2="-1" transform="matrix(-0.707107 0.707107 0.707107 0.707107 26 10)" stroke="var(--dark-grey)" stroke-width="2"/>
+</svg>

--- a/src/components/Configuration.tsx
+++ b/src/components/Configuration.tsx
@@ -136,7 +136,7 @@ export default function Configuration() {
 
       <section className={styles.confirmation}>
         <button onClick={handleApplySettings}>Apply</button>
-        <p>Changes only apply on the next draw</p>
+        <p>Changes only apply starting on the next draw</p>
       </section>
     </aside>
   )

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -90,7 +90,7 @@ export default function FAQ() {
       </FAQSection>
       <FAQSection title="Can I contact you?">
         <p>Sure thing! You can find me on <a target="_blank" href="https://www.linkedin.com/in/inaciomatheusdev/">LinkedIn</a> or <a target="_blank" href="https://www.instagram.com/inaciomatheus_/">Instagram.</a></p>
-        <p>If you have any question, suggestion, complaint, compliment or other concern regarding ColorQuest specifically, you can email me at <span style={{textDecoration: 'line-through'}}>contact@colorquest.me</span> (soon)</p>
+        <p>If you have any question, suggestion, complaint, compliment or other concern regarding ColorQuest specifically, you can email me at contact@colorquest.me.</p>
       </FAQSection>
     </article>
   );

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -38,7 +38,7 @@ function FAQSection(props: {children: ReactNode, title: string}) {
 
 export default function FAQ() {
   return (
-    <article className={styles.faq}>
+    <article id="FAQ" className={styles.faq}>
       <FAQSection title="What's ColorQuest?">
         <p>ColorQuest is a color picking game where your objective is to pick the right color as indicated by the code, be it in RGB or Hex.</p>
         <p>In the future, there will be another game mode where you have to type the code as indicated by the color, and also the HSL code option.</p>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,14 +4,23 @@ import FoldIcon from '../../assets/svg/double-down-arrow.svg';
 import styles from '../styles/modules/Footer.module.css';
 
 export default function Footer( props: { style: 'main' | 'alt' } ) {
+  function handleFoldClick(direction: 'down' | 'up') {
+    const targetElement = direction === 'down' ? document.getElementById('FAQ') : document.getElementById('header');
+
+    targetElement.scrollIntoView({behavior: 'smooth'});
+  }
+
   return (
     <footer className={`${styles.footer} ${props.style === 'alt' ? styles.last : null}`}>
       {props.style === 'main' ? 
         <Fragment>
           <span>enjoy the game?</span> <a href="https://buymeacoffee.com/heyset" target="_blank"><img src="./svg/bmc-logo.svg" alt="buy me a coffee logo"/> buy me a coffee</a>:)
-          <FoldIcon />
+          <FoldIcon className={styles.foldIcon} onClick={() => handleFoldClick('down')}/>
         </Fragment>:
-        <p>Created with &#x2665; and &#x2615; by <a href="https://github.com/heyset" target="_blank">Matheus "Set" Inacio</a>, 2021.</p>
+        <Fragment>
+          <p>Created with &#x2665; and &#x2615; by <a href="https://github.com/heyset" target="_blank">Matheus "Set" Inacio</a>, 2021.</p>
+          <FoldIcon className={`${styles.foldIcon} ${styles.foldIconUp}`} onClick={() => handleFoldClick('up')}/>
+        </Fragment>
       }
     </footer>
   );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,12 +1,16 @@
 import { Fragment } from 'react';
 
+import FoldIcon from '../../assets/svg/double-down-arrow.svg';
 import styles from '../styles/modules/Footer.module.css';
 
 export default function Footer( props: { style: 'main' | 'alt' } ) {
   return (
     <footer className={`${styles.footer} ${props.style === 'alt' ? styles.last : null}`}>
       {props.style === 'main' ? 
-        <Fragment><span>enjoy the game?</span> <a href="https://buymeacoffee.com/heyset" target="_blank"><img src="./svg/bmc-logo.svg" alt="buy me a coffee logo"/> buy me a coffee</a>:)</Fragment>:
+        <Fragment>
+          <span>enjoy the game?</span> <a href="https://buymeacoffee.com/heyset" target="_blank"><img src="./svg/bmc-logo.svg" alt="buy me a coffee logo"/> buy me a coffee</a>:)
+          <FoldIcon />
+        </Fragment>:
         <p>Created with &#x2665; and &#x2615; by <a href="https://github.com/heyset" target="_blank">Matheus "Set" Inacio</a>, 2021.</p>
       }
     </footer>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,7 +2,7 @@ import styles from '../styles/modules/Header.module.css';
 
 export default function Header() {
   return (
-    <header className={styles.header}>
+    <header id="header" className={styles.header}>
       <h1>ColorQuest</h1>
       <h2>become the eyedropper</h2>
     </header>

--- a/src/components/Info.tsx
+++ b/src/components/Info.tsx
@@ -21,8 +21,6 @@ export default function Info( props: { className:string } ) {
   const { drawNewGame } = useContext(ColorContext);
   const [percentToNextLevel, setPercentToNextLevel] = useState(0);
   const [levelUpExp, setLevelUpExp] = useState(0);
-  const [levelUpExpStyle, setLevelUpExpStyle] = useState({width: '0px', height: '10px'});
-  const [currentExpStyle, setCurrentExpStyle] = useState({width: '0px', height: '10px'});
   const [currentWindow, setCurrentWindow] = useState(undefined);
 
   const dict = new Dictionary(Language.ENGLISH);
@@ -69,22 +67,6 @@ export default function Info( props: { className:string } ) {
   }, [currentExp]);
 
   useEffect(() => {
-    if (window.innerWidth < 674) {
-      setCurrentExpStyle({width: `${percentToNextLevel}%`, height: '10px'});
-    } else {
-      setCurrentExpStyle({width: `${percentToNextLevel}%`, height: '20px'});
-    }
-  }, [percentToNextLevel]);
-
-  useEffect(() => {
-    if (window.innerWidth < 674) {
-      setLevelUpExpStyle({width: `${levelUpExp}%`, height: '10px'});
-    } else {
-      setLevelUpExpStyle({width: `${levelUpExp}%`, height: '20px'});
-    }
-  }, [levelUpExp]);
-
-  useEffect(() => {
     setCurrentWindow(window);
   }, []);
 
@@ -100,8 +82,8 @@ export default function Info( props: { className:string } ) {
       </div>
       <div className={styles.container}>
         <div className={styles.bar}>
-          <div className={styles.currentExp} style={currentExpStyle}></div>
-          <div className={styles.expUp} style={levelUpExpStyle}></div>
+          <div className={styles.currentExp} style={{width: `${percentToNextLevel}%`}}></div>
+          <div className={styles.expUp} style={{width: `${levelUpExp}%`}}></div>
         </div>
         <div className={styles.details}>
           {currentWindow && currentWindow.innerWidth < 674 && <span className={styles.levelExp}>

--- a/src/contexts/GameContext.tsx
+++ b/src/contexts/GameContext.tsx
@@ -5,6 +5,7 @@ import { UserProvider } from './UserContext';
 import expTable from '../../assets/expTable.json';
 
 import { ModalType } from '../components/Modal';
+import Color from 'classes/Color';
 
 export enum GameStatus {
   PLAYING,
@@ -20,7 +21,19 @@ export enum Difficulty {
   ULTRAHARD,
 };
 
-const DEFAULTS = {
+interface ConfigInterface {
+  difficulty?: Difficulty;
+  draw?: {color: Color, isTarget: boolean};
+  target?: {color: Color, isTarget: boolean};
+  gameMode?: string;
+  gameStatus?: GameStatus;
+  level?: {index: number, level: number, minExp: number, maxExp: number};
+  rank?: {title: string, difficulty: Difficulty, minLevel: number, maxLevel: number, index: number};
+  experience?: number;
+  streak?: number;
+}
+
+const DEFAULTS:ConfigInterface = {
   difficulty: Difficulty.EASY,
   draw: null,
   target: null,
@@ -38,8 +51,8 @@ const DEFAULTS = {
   streak: 0,
 }
 
-export function getLoadedConfigurations(localStorage: Storage, ...keys: string[]) {
-  const loadedConfigs:any = {};
+export function getLoadedConfigurations(localStorage: Storage, ...keys: string[]):ConfigInterface {
+  const loadedConfigs:ConfigInterface = {};
 
   keys.forEach((key) => {
     const stored = localStorage.getItem(key);

--- a/src/contexts/GameContext.tsx
+++ b/src/contexts/GameContext.tsx
@@ -24,7 +24,7 @@ export enum Difficulty {
 interface ConfigInterface {
   difficulty?: Difficulty;
   draw?: {color: Color, isTarget: boolean}[];
-  target?: {color: Color, isTarget: boolean};
+  target?: Color;
   gameMode?: string;
   gameStatus?: GameStatus;
   level?: {index: number, level: number, minExp: number, maxExp: number};

--- a/src/contexts/GameContext.tsx
+++ b/src/contexts/GameContext.tsx
@@ -23,7 +23,7 @@ export enum Difficulty {
 
 interface ConfigInterface {
   difficulty?: Difficulty;
-  draw?: {color: Color, isTarget: boolean};
+  draw?: {color: Color, isTarget: boolean}[];
   target?: {color: Color, isTarget: boolean};
   gameMode?: string;
   gameStatus?: GameStatus;

--- a/src/styles/modules/Footer.module.css
+++ b/src/styles/modules/Footer.module.css
@@ -6,6 +6,7 @@
   height: 10%;
   font-size: 0.80rem;
   color: var(--text-muted);
+  position: relative;
 }
 
 @media screen and (min-width: 960px) {
@@ -22,4 +23,52 @@
 
 .last {
   margin: 22px 0;
+}
+
+.foldIcon {
+  position: absolute;
+  bottom: 18px;
+  right: 18px;
+  cursor: pointer;
+}
+
+.foldIconUp {
+  transform: rotate(180deg);
+  bottom: 24px;
+}
+
+.foldIcon:hover {
+  animation: jump 300ms ease-out 1;
+}
+
+.foldIconUp:hover {
+  animation: jumpReverse 300ms ease-out 1;
+}
+
+@keyframes jump {
+  0% {
+    transform: translateY(0);
+  }
+
+  50% {
+    transform: translateY(40%);
+  }
+
+  100% {
+    transform: translateY(0);
+  }
+}
+
+@keyframes jumpReverse {
+  0% {
+    transform: rotate(180deg) translateY(0);
+  }
+
+  50% {
+    transform: rotate(180deg) translateY(40%);
+  }
+
+  100% {
+    transform: rotate(180deg) translateY(0);
+  }
 }


### PR DESCRIPTION
- [x] There should be a small indication that there is content under the fold, as suggested on the Wireframe.
- [x] Grammar error on the phrase "Changes only apply _on_ the next draw", should be "starting on"
- [x] There is some mess on the code remaining from the early attempts to adapt the layout to the desktop. Styling is an object on the exp bars. This isn't needed anymore.
- [x] The professional email contact@colorquest.me is already available, so it should be noted on the "contact" section of the FAQ.

resolves #40 